### PR TITLE
Configure dependabot for Go modules and github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Go Modules dependencies
+  - package-ecosystem: "gomod"
+    directory: "/" 
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+    assignees:
+      - "abrakingoo"
+      - "jesee-kuya"
+      - "JoabOwala"
+      - "johneliud"
+      - "kh3rld"
+      - "Tomlee-abila"
+    labels:
+      - "dependencies"
+      - "go-modules"
+    ignore:
+      - dependency-name: "golang.org/x/*"
+        versions: ["<1.21"] 
+
+  # GitHub Actions dependencies
+  - package-ecosystem: "github-actions"
+    directory: "/" 
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci/cd"


### PR DESCRIPTION
- Set up weekly updates for Go Modules dependencies.
- Assigned multiple maintainers for pull request management.
- Added labels: "dependencies" and "go-modules" for categorization.
- Ignored golang.org/x/* dependencies below version 1.21.
- Limited open pull requests to a maximum of 10.
