### PR TITLE
Update workflow for artifact actions v3 deprecation

### DIFF
--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -84,13 +84,13 @@ jobs:
         continue-on-error: false
 
       - name: Upload Coverage Report
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: coverage.out
 
       - name: Upload Test Results
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: test-results
           path: tests.log


### PR DESCRIPTION
- check out the deprecation notice [here](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

- Read more: https://github.blog/news-insights/product-news/get-started-with-v4-of-github-actions-artifacts/

