### PR TITLE
fix: resolve infinite error loop in script execution due to flag redefinition on panic

### DIFF
--- a/cmd/repl/main.go
+++ b/cmd/repl/main.go
@@ -9,7 +9,13 @@ import (
 	"github.com/Zone01-Kisumu-Open-Source-Projects/kisumu-lang/pkg/logger"
 )
 
+var file = flag.String("file", "", "Source file to execute")
+
 func main() {
+	if !flag.Parsed() {
+		flag.Parse()
+	}
+
 	// Initialize logger with debug level in dev, info in production
 	logLevel := slog.LevelInfo
 	if os.Getenv("KSM_DEBUG") != "" {
@@ -25,14 +31,11 @@ func main() {
 		if r := recover(); r != nil {
 			logger.Error("REPL panic recovered",
 				slog.Any("error", r),
-				slog.String("action", "restarting REPL"),
+				slog.String("action", "exiting REPL"),
 			)
-			main() // Restart on panic
+			os.Exit(1)
 		}
 	}()
-
-	file := flag.String("file", "", "Source file to execute")
-	flag.Parse()
 
 	logger.Info("Starting Kisumu REPL",
 		slog.String("version", "0.4.0"),
@@ -46,7 +49,7 @@ func main() {
 				slog.String("error", err.Error()),
 			)
 			cleanup()
-			panic("File execution failed")
+			os.Exit(1)
 		}
 		cleanup()
 		return
@@ -54,12 +57,28 @@ func main() {
 
 	logger.Warn("No input file provided - entering interactive mode")
 	// fmt.Println("Kisumu REPL (type :exit to quit)")
+	
+	// Run REPL with panic recovery for interactive mode
+	runInteractiveREPL()
+}
+
+func runInteractiveREPL() {
+	defer func() {
+		if r := recover(); r != nil {
+			logger.Error("REPL panic recovered",
+				slog.Any("error", r),
+				slog.String("action", "restarting REPL"),
+			)
+			runInteractiveREPL() // Restart on panic
+		}
+	}()
+
 	if err := repl.Start(); err != nil {
 		logger.Error("Failed to start REPL",
 			slog.String("error", err.Error()),
 			slog.String("action", "exiting REPL"),
 		)
-		panic("REPL startup failed")
+		os.Exit(1)
 	}
 }
 


### PR DESCRIPTION
Closes #86

This PR resolves an issue where running a script with an invalid variable declaration (or any parser error) caused an infinite loop of `flag redefined: file` panics. 

The root cause was that any panic intentionally thrown during file execution to indicate failure was caught by a deferred `recover()` block that attempted to restart `main()`. Restarting `main()` executed `flag.String("file", ...)` again, resulting in another panic, leading to an infinite cycle.

**Changes:**
- Extracted the REPL restart logic into a separate `runInteractiveREPL()` function for interactive mode.
- Modified `main()` to gracefully exit using `os.Exit(1)` upon file execution failures, rather than throwing a panic that triggers a recursive restart loop.
- Ensured `flag.Parse()` handles re-runs properly if `main()` were ever re-entered.
