### PR TITLE
FIX: resolve flag redefined panic on REPL restart

### DIFF
--- a/cmd/repl/main.go
+++ b/cmd/repl/main.go
@@ -9,6 +9,9 @@ import (
 	"github.com/Zone01-Kisumu-Open-Source-Projects/kisumu-lang/pkg/logger"
 )
 
+// Declared only once so that flag.String is called once
+var file = flag.String("file", "", "path to source file")
+
 func main() {
 	// Initialize logger with debug level in dev, info in production
 	logLevel := slog.LevelInfo
@@ -21,17 +24,6 @@ func main() {
 		AddSource: true,
 	})
 
-	defer func() {
-		if r := recover(); r != nil {
-			logger.Error("REPL panic recovered",
-				slog.Any("error", r),
-				slog.String("action", "restarting REPL"),
-			)
-			main() // Restart on panic
-		}
-	}()
-
-	file := flag.String("file", "", "Source file to execute")
 	flag.Parse()
 
 	logger.Info("Starting Kisumu REPL",
@@ -46,7 +38,7 @@ func main() {
 				slog.String("error", err.Error()),
 			)
 			cleanup()
-			panic("File execution failed")
+			os.Exit(1)
 		}
 		cleanup()
 		return


### PR DESCRIPTION
- declare -file flag at package level to prevent re-registration
- replace recursive main() recovery with os.Exit(1)

##Description
Fixes a flag redefined panic that caused the REPL to enter an infinite restart loop when the -file flag was re-registered on each recursive main() call.

#### Related Issue(s)
- Resolves: #86
- References: #86


### Changes Made
-  Declare -file flag at package level so flag.String is called once
- Remove recursive main() panic recovery and replace with os.Exit(1)


### How to Test
1. Run ```go run ./cmd/repl/main.go -file test.ks```
2. Confirm REPL starts in file mode and executes without panic loop
3. Run ```go run ./cmd/repl/main.go``` to confirm interactive mode still works


### Checklist
-  My code adheres to the project's coding guidelines
-  I have manually tested the changes in my local environment

### Notes for Reviewer(s)
The recursive ```main()``` call in the file recovterer was the root cause of the error since  each restart re -registered the ```-file``` flag, which the flag package does not allow.  This triggered the panic and the infinite loop.
